### PR TITLE
Separate @types/css-font-loading-module into its own group

### DIFF
--- a/default.json
+++ b/default.json
@@ -21,6 +21,11 @@
       "matchFiles": ["package.json"],
       "rangeStrategy": "update-lockfile"
   }, {
+      "groupName": "@types/css-font-loading-module",
+      "matchPackagePrefixes": [
+        "@types/css-font-loading-module"
+      ]
+  }, {
       "groupName": "react-types",
       "matchPackagePrefixes": [
         "@types/react"


### PR DESCRIPTION
in the hope that this will allow us to close the renovate PR for it, because it's currently broken.