### PR TITLE
Disable semantic commit comments

### DIFF
--- a/default.json
+++ b/default.json
@@ -16,6 +16,7 @@
       ":dependencyDashboardApproval"
   ],
   "labels": ["T-Task", "Dependencies"],
+  "semanticCommits": "disabled",
   "lockFileMaintenance": { "enabled": true },
   "packageRules": [{
       "matchFiles": ["package.json"],


### PR DESCRIPTION
... because semantic commits are a terrible idea, and we don't use them in the eleweb stack.